### PR TITLE
Add simple spell HUD

### DIFF
--- a/Scenes/Nodes/Character/Player.cs
+++ b/Scenes/Nodes/Character/Player.cs
@@ -12,6 +12,7 @@ public partial class Player : CharacterBody2D
     [Export] public int Health = 100;
 
     private PlayerHealthBar _healthBar;
+    private SpellHUD _spellHUD;
     private Vector2 _targetPosition;
     private bool _isMoving = false;
 
@@ -47,6 +48,8 @@ public partial class Player : CharacterBody2D
 
     public String IndicatorLocation = "res://Scenes//Nodes//HUD//Indicator//Indicator.tscn";
 
+    public string SpellHUDLocation = "res://Scenes/Nodes/HUD/SpellHUD.tscn";
+
     /*
     public PackedScene FireballScene = (PackedScene)GD.Load("res://Scenes//Nodes//Spells//Fireball//Fireball.tscn");
     public PackedScene DashScene = (PackedScene)GD.Load("res://Scenes//Nodes//Spells//Dash//Dash.tscn");
@@ -57,6 +60,7 @@ public partial class Player : CharacterBody2D
     private Spell _fireboltSpell;
     */
     public PackedScene IndicatorScene;
+    public PackedScene SpellHUDScene;
 
     public AnimationTree AnimationTree;
 
@@ -131,6 +135,7 @@ public partial class Player : CharacterBody2D
         _navigationAgent.PathDesiredDistance = 1.0f;
 
         IndicatorScene = (PackedScene)GD.Load(IndicatorLocation);
+        SpellHUDScene = (PackedScene)GD.Load(SpellHUDLocation);
 
         PlayerSprite = this.GetNode<Sprite2D>("Sprite");
 
@@ -138,6 +143,13 @@ public partial class Player : CharacterBody2D
         if (_healthBar != null)
         {
             _healthBar.UpdateHealth(Health, MaxHealth);
+        }
+
+        if (SpellHUDScene != null)
+        {
+            _spellHUD = (SpellHUD)SpellHUDScene.Instantiate();
+            AddChild(_spellHUD);
+            _spellHUD.SpellBook = spellBook;
         }
 
         AnimationTree = this.GetNode<AnimationTree>("AnimationTree");

--- a/Scenes/Nodes/Character/Player.tscn
+++ b/Scenes/Nodes/Character/Player.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://c1mgeayn8x1wh" path="res://Game Assets/wizard_anims/run.png" id="4_y7enw"]
 [ext_resource type="Script" path="res://Scenes/Nodes/Character/PlayerSight.cs" id="4_ymb08"]
 [ext_resource type="PackedScene" path="res://Scenes/Nodes/HUD/PlayerHealthBar.tscn" id="5_phb"]
+[ext_resource type="PackedScene" path="res://Scenes/Nodes/HUD/SpellHUD.tscn" id="6_spellhud"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_iabyq"]
 
@@ -479,3 +480,5 @@ script = ExtResource("4_ymb08")
 ShowDebugMarkers = true
 [node name="PlayerHealthBar" parent="." instance=ExtResource("5_phb")]
 position = Vector2(0, -20)
+[node name="SpellHUD" parent="." instance=ExtResource("6_spellhud")]
+position = Vector2(-36, 20)

--- a/Scenes/Nodes/HUD/SpellHUD.cs
+++ b/Scenes/Nodes/HUD/SpellHUD.cs
@@ -1,0 +1,70 @@
+using Godot;
+using System.Collections.Generic;
+using DungeonsAlltheWayDown.AbilitySystem;
+
+public partial class SpellHUD : Node2D
+{
+    private class Slot
+    {
+        public Sprite2D Icon;
+        public Label KeyLabel;
+    }
+
+    private List<Slot> _slots = new();
+
+    [Export] public Texture2D DefaultIcon;
+
+    public SpellBook SpellBook { get; set; }
+
+    public override void _Ready()
+    {
+        if (DefaultIcon == null)
+        {
+            DefaultIcon = GD.Load<Texture2D>("res://Game Assets/HUD/07.png");
+        }
+
+        for (int i = 0; i < 4; i++)
+        {
+            var slotNode = GetNode<Node2D>($"Slot{i}");
+            var icon = slotNode.GetNode<Sprite2D>("Icon");
+            var label = slotNode.GetNode<Label>("KeyLabel");
+            _slots.Add(new Slot { Icon = icon, KeyLabel = label });
+        }
+    }
+
+    public override void _Process(double delta)
+    {
+        if (SpellBook == null) return;
+
+        for (int i = 0; i < _slots.Count; i++)
+        {
+            var slot = _slots[i];
+            if (SpellBook.Pages.ContainsKey(i))
+            {
+                var spell = SpellBook.Pages[i].Spell;
+                if (slot.Icon.Texture == null)
+                    slot.Icon.Texture = DefaultIcon;
+                slot.KeyLabel.Text = GetKeyName(i);
+                slot.Icon.Modulate = spell.IsReady ? Colors.White : new Color(1,1,1,0.5f);
+            }
+            else
+            {
+                slot.Icon.Texture = DefaultIcon;
+                slot.KeyLabel.Text = GetKeyName(i);
+                slot.Icon.Modulate = new Color(1,1,1,0.25f);
+            }
+        }
+    }
+
+    private string GetKeyName(int index)
+    {
+        return index switch
+        {
+            0 => "Q",
+            1 => "W",
+            2 => "E",
+            3 => "R",
+            _ => string.Empty
+        };
+    }
+}

--- a/Scenes/Nodes/HUD/SpellHUD.tscn
+++ b/Scenes/Nodes/HUD/SpellHUD.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://Scenes/Nodes/HUD/SpellHUD.cs" id="1"]
+[ext_resource type="Texture2D" path="res://Game Assets/HUD/07.png" id="2"]
+
+[node name="SpellHUD" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Slot0" type="Node2D" parent="."]
+position = Vector2(0, 0)
+[node name="Icon" type="Sprite2D" parent="Slot0"]
+texture = ExtResource("2")
+[node name="KeyLabel" type="Label" parent="Slot0"]
+position = Vector2(0, 20)
+text = "Q"
+
+[node name="Slot1" type="Node2D" parent="."]
+position = Vector2(24, 0)
+[node name="Icon" type="Sprite2D" parent="Slot1"]
+texture = ExtResource("2")
+[node name="KeyLabel" type="Label" parent="Slot1"]
+position = Vector2(0, 20)
+text = "W"
+
+[node name="Slot2" type="Node2D" parent="."]
+position = Vector2(48, 0)
+[node name="Icon" type="Sprite2D" parent="Slot2"]
+texture = ExtResource("2")
+[node name="KeyLabel" type="Label" parent="Slot2"]
+position = Vector2(0, 20)
+text = "E"
+
+[node name="Slot3" type="Node2D" parent="."]
+position = Vector2(72, 0)
+[node name="Icon" type="Sprite2D" parent="Slot3"]
+texture = ExtResource("2")
+[node name="KeyLabel" type="Label" parent="Slot3"]
+position = Vector2(0, 20)
+text = "R"


### PR DESCRIPTION
## Summary
- create `SpellHUD` scene and script to display four spell slots
- hook up `SpellHUD` to the player scene and script

## Testing
- `dotnet build` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f51ed6c08332806c054a318e1043