### PR TITLE
Attach SpellHUD to camera

### DIFF
--- a/BaseClasses/Spell.cs
+++ b/BaseClasses/Spell.cs
@@ -7,6 +7,7 @@ public abstract partial class Spell : Node2D
     [Export] public float Cooldown = 0.5f;
     [Export] public float SpellRange;
     public bool IsReady = true;
+    public float CooldownRemaining { get; private set; }
     [Export] public PackedScene SpellEffectScene;
 
 
@@ -23,11 +24,23 @@ public abstract partial class Spell : Node2D
         // Initialize the spell (e.g., load resources, set up effects)
     }
 
-    protected async void StartCooldown()
+    protected void StartCooldown()
     {
         IsReady = false;
-        await ToSignal(GetTree().CreateTimer(Cooldown), "timeout");
-        IsReady = true;
+        CooldownRemaining = Cooldown;
+    }
+
+    public override void _Process(double delta)
+    {
+        if (!IsReady)
+        {
+            CooldownRemaining -= (float)delta;
+            if (CooldownRemaining <= 0)
+            {
+                CooldownRemaining = 0;
+                IsReady = true;
+            }
+        }
     }
     
 }

--- a/Scenes/Nodes/Character/Player.cs
+++ b/Scenes/Nodes/Character/Player.cs
@@ -48,7 +48,6 @@ public partial class Player : CharacterBody2D
 
     public String IndicatorLocation = "res://Scenes//Nodes//HUD//Indicator//Indicator.tscn";
 
-    public string SpellHUDLocation = "res://Scenes/Nodes/HUD/SpellHUD.tscn";
 
     /*
     public PackedScene FireballScene = (PackedScene)GD.Load("res://Scenes//Nodes//Spells//Fireball//Fireball.tscn");
@@ -60,7 +59,6 @@ public partial class Player : CharacterBody2D
     private Spell _fireboltSpell;
     */
     public PackedScene IndicatorScene;
-    public PackedScene SpellHUDScene;
 
     public AnimationTree AnimationTree;
 
@@ -135,7 +133,6 @@ public partial class Player : CharacterBody2D
         _navigationAgent.PathDesiredDistance = 1.0f;
 
         IndicatorScene = (PackedScene)GD.Load(IndicatorLocation);
-        SpellHUDScene = (PackedScene)GD.Load(SpellHUDLocation);
 
         PlayerSprite = this.GetNode<Sprite2D>("Sprite");
 
@@ -145,10 +142,9 @@ public partial class Player : CharacterBody2D
             _healthBar.UpdateHealth(Health, MaxHealth);
         }
 
-        if (SpellHUDScene != null)
+        _spellHUD = GetNode<SpellHUD>("Camera2D/SpellHUD");
+        if (_spellHUD != null)
         {
-            _spellHUD = (SpellHUD)SpellHUDScene.Instantiate();
-            AddChild(_spellHUD);
             _spellHUD.SpellBook = spellBook;
         }
 

--- a/Scenes/Nodes/Character/Player.tscn
+++ b/Scenes/Nodes/Character/Player.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://c1mgeayn8x1wh" path="res://Game Assets/wizard_anims/run.png" id="4_y7enw"]
 [ext_resource type="Script" path="res://Scenes/Nodes/Character/PlayerSight.cs" id="4_ymb08"]
 [ext_resource type="PackedScene" uid="uid://yik37x68b1ek" path="res://Scenes/Nodes/HUD/PlayerHealthBar.tscn" id="5_phb"]
+[ext_resource type="PackedScene" uid="uid://y0og8l57cq8u" path="res://Scenes/Nodes/HUD/SpellHUD.tscn" id="6_sphud"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_iabyq"]
 
@@ -445,6 +446,8 @@ script = ExtResource("1_m8ucb")
 zoom = Vector2(0.1, 0.1)
 drag_horizontal_enabled = true
 drag_vertical_enabled = true
+
+[node name="SpellHUD" parent="Camera2D" instance=ExtResource("6_sphud")]
 
 [node name="Sprite" type="Sprite2D" parent="."]
 position = Vector2(0, -3)

--- a/Scenes/Nodes/HUD/SpellHUD.cs
+++ b/Scenes/Nodes/HUD/SpellHUD.cs
@@ -8,6 +8,7 @@ public partial class SpellHUD : Node2D
     {
         public Sprite2D Icon;
         public Label KeyLabel;
+        public Label CooldownLabel;
     }
 
     private List<Slot> _slots = new();
@@ -28,7 +29,8 @@ public partial class SpellHUD : Node2D
             var slotNode = GetNode<Node2D>($"Slot{i}");
             var icon = slotNode.GetNode<Sprite2D>("Icon");
             var label = slotNode.GetNode<Label>("KeyLabel");
-            _slots.Add(new Slot { Icon = icon, KeyLabel = label });
+            var cdLabel = slotNode.GetNodeOrNull<Label>("CooldownLabel");
+            _slots.Add(new Slot { Icon = icon, KeyLabel = label, CooldownLabel = cdLabel });
         }
     }
 
@@ -46,12 +48,27 @@ public partial class SpellHUD : Node2D
                     slot.Icon.Texture = DefaultIcon;
                 slot.KeyLabel.Text = GetKeyName(i);
                 slot.Icon.Modulate = spell.IsReady ? Colors.White : new Color(1,1,1,0.5f);
+
+                if (slot.CooldownLabel != null)
+                {
+                    if (spell.IsReady)
+                    {
+                        slot.CooldownLabel.Visible = false;
+                    }
+                    else
+                    {
+                        slot.CooldownLabel.Visible = true;
+                        slot.CooldownLabel.Text = Mathf.Ceil(spell.CooldownRemaining).ToString();
+                    }
+                }
             }
             else
             {
                 slot.Icon.Texture = DefaultIcon;
                 slot.KeyLabel.Text = GetKeyName(i);
                 slot.Icon.Modulate = new Color(1,1,1,0.25f);
+                if (slot.CooldownLabel != null)
+                    slot.CooldownLabel.Visible = false;
             }
         }
     }

--- a/Scenes/Nodes/HUD/SpellHUD.tscn
+++ b/Scenes/Nodes/HUD/SpellHUD.tscn
@@ -14,6 +14,11 @@ script = ExtResource("1")
 [node name="Icon" type="Sprite2D" parent="Slot0"]
 texture = ExtResource("2_wa6ry")
 
+[node name="CooldownLabel" type="Label" parent="Slot0"]
+offset_top = 0.0
+offset_bottom = 20.0
+text = ""
+
 [node name="KeyLabel" type="Label" parent="Slot0"]
 offset_top = 20.0
 offset_bottom = 20.0
@@ -24,6 +29,11 @@ position = Vector2(48, 0)
 
 [node name="Icon" type="Sprite2D" parent="Slot1"]
 texture = ExtResource("3_x4bqx")
+
+[node name="CooldownLabel" type="Label" parent="Slot1"]
+offset_top = 0.0
+offset_bottom = 20.0
+text = ""
 
 [node name="KeyLabel" type="Label" parent="Slot1"]
 offset_top = 20.0
@@ -36,6 +46,11 @@ position = Vector2(96, 0)
 [node name="Icon" type="Sprite2D" parent="Slot2"]
 texture = ExtResource("4_hbqfd")
 
+[node name="CooldownLabel" type="Label" parent="Slot2"]
+offset_top = 0.0
+offset_bottom = 20.0
+text = ""
+
 [node name="KeyLabel" type="Label" parent="Slot2"]
 offset_top = 20.0
 offset_bottom = 20.0
@@ -46,6 +61,11 @@ position = Vector2(144, 0)
 
 [node name="Icon" type="Sprite2D" parent="Slot3"]
 texture = ExtResource("5_e1et7")
+
+[node name="CooldownLabel" type="Label" parent="Slot3"]
+offset_top = 0.0
+offset_bottom = 20.0
+text = ""
 
 [node name="KeyLabel" type="Label" parent="Slot3"]
 offset_top = 20.0


### PR DESCRIPTION
## Summary
- connect SpellHUD directly under the player's camera
- expose spell cooldown values and update HUD with remaining time
- add cooldown labels to SpellHUD slots

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611327bce083328a3208ba0ba28019