### PR TITLE
Add enemy lifebar support

### DIFF
--- a/BaseClasses/LevelEntities/NPC/HostileNPC.cs
+++ b/BaseClasses/LevelEntities/NPC/HostileNPC.cs
@@ -10,6 +10,9 @@ using Godot.Collections;
 public abstract partial class HostileNPC : LevelEntity
 {
     [Export]
+    public int MaxHealth = 100;
+
+    [Export]
     public int Health = 100;
 
     [Export]
@@ -32,6 +35,8 @@ public abstract partial class HostileNPC : LevelEntity
     private Player _target;
 
     public Sprite2D CharacterSprite;
+
+    private EnemyHealthBar _healthBar;
 
     private StateEnum _currentState;
     private Vector2 lastKnownPosition;
@@ -87,6 +92,12 @@ public abstract partial class HostileNPC : LevelEntity
         //GD.Print(_navigationAgent);
 
         LoadSprite(GetSpriteName());
+
+        _healthBar = GetNodeOrNull<EnemyHealthBar>("EnemyHealthBar");
+        if (_healthBar != null)
+        {
+            _healthBar.UpdateHealth(Health, MaxHealth);
+        }
 
     }
     
@@ -275,6 +286,14 @@ public abstract partial class HostileNPC : LevelEntity
     public virtual void OnHit(int Damage)
     {
         Health -= Damage;
+        if (Health < 0)
+            Health = 0;
+
+        if (_healthBar != null)
+        {
+            _healthBar.UpdateHealth(Health, MaxHealth);
+        }
+
         GD.Print(Health);
 
         DeathCheck();

--- a/Scenes/Nodes/HUD/EnemyHealthBar.cs
+++ b/Scenes/Nodes/HUD/EnemyHealthBar.cs
@@ -1,0 +1,20 @@
+using Godot;
+
+public partial class EnemyHealthBar : Node2D
+{
+    private ProgressBar _bar;
+
+    public override void _Ready()
+    {
+        _bar = GetNode<ProgressBar>("ProgressBar");
+    }
+
+    public void UpdateHealth(int health, int maxHealth)
+    {
+        if (_bar != null)
+        {
+            _bar.MaxValue = maxHealth;
+            _bar.Value = health;
+        }
+    }
+}

--- a/Scenes/Nodes/HUD/EnemyHealthBar.tscn
+++ b/Scenes/Nodes/HUD/EnemyHealthBar.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://Scenes/Nodes/HUD/EnemyHealthBar.cs" id="1"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0.697921, 0.256073, 0.312054, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+corner_detail = 10
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fill"]
+bg_color = Color(0.6, 0, 0, 1)
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="Theme" id="Theme_default"]
+ProgressBar/colors/font_color = Color(1, 1, 1, 1)
+ProgressBar/colors/font_outline_color = Color(0, 0, 0, 1)
+ProgressBar/styles/background = SubResource("StyleBoxFlat_bg")
+ProgressBar/styles/fill = SubResource("StyleBoxFlat_fill")
+
+[node name="EnemyHealthBar" type="Node2D"]
+z_index = 3
+scale = Vector2(0.5, 0.5)
+script = ExtResource("1")
+
+[node name="ProgressBar" type="ProgressBar" parent="."]
+offset_left = -100.0
+offset_top = -45.0
+offset_right = 100.0
+offset_bottom = -18.0
+theme = SubResource("Theme_default")
+value = 100.0

--- a/Scenes/Nodes/NPC/Enemies/TestEnemy_1/TestEnemy_1.tscn
+++ b/Scenes/Nodes/NPC/Enemies/TestEnemy_1/TestEnemy_1.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=36 format=3 uid="uid://c0jcwm1hcf0mh"]
+[gd_scene load_steps=37 format=3 uid="uid://c0jcwm1hcf0mh"]
 
 [ext_resource type="Script" path="res://Scenes/Nodes/NPC/Enemies/TestEnemy_1/Testenemy_1Script.cs" id="1_fnm3s"]
 [ext_resource type="Texture2D" uid="uid://blv25nnpswb6f" path="res://Game Assets/Enemy/Skeleton Crew/Skeleton - Base/Run/Run-Sheet.png" id="1_x3wkd"]
 [ext_resource type="Texture2D" uid="uid://g876huqlmrdx" path="res://Game Assets/Enemy/Skeleton Crew/Skeleton - Base/Idle/Idle-Sheet.png" id="2_xkkas"]
 [ext_resource type="Texture2D" uid="uid://ctqrsohtq0kfy" path="res://Game Assets/Enemy/Skeleton Crew/Skeleton - Base/Death/Death-Sheet.png" id="3_ge1ai"]
+[ext_resource type="PackedScene" path="res://Scenes/Nodes/HUD/EnemyHealthBar.tscn" id="4_ehb"]
 
 [sub_resource type="Animation" id="Animation_3uhl6"]
 resource_name = "Death"
@@ -343,3 +344,7 @@ shape = SubResource("CircleShape2D_cdxql")
 debug_enabled = true
 debug_use_custom = true
 debug_path_custom_point_size = 0.47
+
+[node name="EnemyHealthBar" parent="." instance=ExtResource("4_ehb")]
+position = Vector2(0, -30)
+scale = Vector2(0.2, 0.2)


### PR DESCRIPTION
## Summary
- create `EnemyHealthBar` control and scene
- show enemy health in `HostileNPC` base class
- place health bar on TestEnemy1 scene

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68623fb63f6083329367f09857f201ff